### PR TITLE
Switch to log4r for debug messages

### DIFF
--- a/Buckeroo.gemspec
+++ b/Buckeroo.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'poltergeist'
   s.add_dependency 'rest-client'
+  s.add_dependency 'log4r'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     buckaroo (0.0.1.pre)
+      log4r
       rest-client
 
 GEM
@@ -14,9 +15,15 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.2.2)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    log4r (1.1.10)
     mime-types (1.25)
     mini_portile (0.5.2)
     multi_json (1.8.2)
+    netrc (0.10.3)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     poltergeist (1.4.1)
@@ -27,12 +34,17 @@ GEM
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     websocket-driver (0.3.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Buckaroo ruby gem
 
+[![Build Status](http://drone.hoppinger.com/api/badges/hoppinger/buckaroo/status.svg)](http://drone.hoppinger.com/hoppinger/buckaroo)
+
 This is a gem to allow buckaroo payments against BPE 3.0. Its right now under development
 but will be released in the next couple of days.
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ Rake::TestTask.new 'test:unit' do |t|
 end
 
 task :uninstall do
-  puts 'Unintalling..'
+  puts 'Uninstalling..'
   `gem uninstall buckaroo -ax`
   `rbenv rehash`
 end

--- a/lib/buckaroo.rb
+++ b/lib/buckaroo.rb
@@ -55,6 +55,7 @@ module Buckaroo
       request = {}
 
       request['brq_currency'] = 'EUR'
+      request['brq_requestedservices'] = hash[:requested_services].join(',')
       request['brq_culture'] = 'en-EN'
       request['brq_continue_on_incomplete'] = 'RedirectToHTML'
 

--- a/lib/buckaroo.rb
+++ b/lib/buckaroo.rb
@@ -71,7 +71,7 @@ module Buckaroo
 
     def gateway
       return "https://testcheckout.buckaroo.nl/nvp/" if test?
-      "https://testcheckout.buckaroo.nl/nvp/"
+      "https://checkout.buckaroo.nl/nvp/"
     end
   end
 

--- a/lib/buckaroo.rb
+++ b/lib/buckaroo.rb
@@ -55,8 +55,7 @@ module Buckaroo
       request = {}
 
       request['brq_currency'] = 'EUR'
-      request['brq_requestedservices'] = 'ideal,transfer'
-      request['brq_culture'] = 'nl-NL'
+      request['brq_culture'] = 'en-EN'
       request['brq_continue_on_incomplete'] = 'RedirectToHTML'
 
       request['brq_push'] = Buckaroo.push if Buckaroo.push

--- a/lib/buckaroo.rb
+++ b/lib/buckaroo.rb
@@ -7,25 +7,22 @@ module Buckaroo
 
   class << self
 
-    attr_accessor :key, :secret, :callback, :debug, :test, :push
+    attr_accessor :key, :secret, :callback, :debug, :test, :push, :log
     def debug?; debug end;
     def test?; test; end;
 
-    def initialize
-      @log = Log4r::Logger.new('log')
-      @log.outputters << Log4r::StdoutOutputter.new('log_stdout')
-    end
-
     def execute!(hash, operation)
+      self.log = Log4r::Logger.new('log')
+      log.outputters << Log4r::StdoutOutputter.new('log_stdout')
 
       nvp = hash.dup
       nvp['brq_websitekey'] = @key
       nvp['brq_signature'] = Hasher.calculate(nvp, @secret)
 
       if debug
-        @log.info "------------------------"
-        @log.info "=> Request: #{operation}"
-        @log.info nvp.inspect
+        log.debug "------------------------"
+        log.debug "=> Request: #{operation}"
+        log.debug nvp.inspect
       end
 
       response_body = RestClient.post "#{gateway}?op=#{operation}", nvp
@@ -35,10 +32,10 @@ module Buckaroo
       h.collect { |k| reponse_hash[k[0]] = k[1] }
 
       if debug
-        @log.debug
-        @log.debug "<= Response: #{operation}"
-        @log.debug reponse_hash.inspect
-        @log.debug "------------------------"
+        log.debug ""
+        log.debug "<= Response: #{operation}"
+        log.debug reponse_hash.inspect
+        log.debug "------------------------"
       end
 
       raise "Signature doesn't match" unless Hasher.valid?(reponse_hash, @secret)


### PR DESCRIPTION
- Fix type while uninstalling
- Change `puts` to log4r logger
